### PR TITLE
[streaming] Ping-pong от клиента к серверу

### DIFF
--- a/streaming_client.go
+++ b/streaming_client.go
@@ -13,6 +13,9 @@ import (
 
 const StreamingApiURL = "wss://api-invest.tinkoff.ru/openapi/md/v1/md-openapi/ws"
 
+const DefaultPongWait = 60 * time.Second
+const DefaultPingPeriod = 54 * time.Second
+
 type Logger interface {
 	Printf(format string, args ...interface{})
 }
@@ -34,13 +37,17 @@ func NewStreamingClient(logger Logger, token string) (*StreamingClient, error) {
 }
 
 func NewStreamingClientCustom(logger Logger, token, apiURL string) (*StreamingClient, error) {
+	return NewStreamingClientCustomPingPong(logger, token, apiURL, DefaultPongWait, DefaultPingPeriod)
+}
+
+func NewStreamingClientCustomPingPong(logger Logger, token, apiURL string, pongWait time.Duration, pingPeriod time.Duration) (*StreamingClient, error) {
 	client := &StreamingClient{
 		logger: logger,
 		token:  token,
 		apiURL: apiURL,
 
-		pongWait:   60 * time.Second,
-		pingPeriod: 54 * time.Second,
+		pongWait:   pongWait,
+		pingPeriod: pingPeriod,
 	}
 
 	conn, err := client.connect()


### PR DESCRIPTION
### Проблема
Если у работающего робота отключить интернет, он об этом не узнает, т.к. клиент не пытается пинговать сервер.

### Решение
Добавлена периодическая отправка ping-пакета на сервер с ожиданием pong-ответа. Для конфигурации таймингов, добавлен новый конструктор Streaming Client. При отсутствии pong-а в указанный таймаут, клиентский код получает error и может реализовать собственную логику переподключения к сокету и переподписки на интересующие события.

Сохранена обратная совместимость. Использование ping-pong включается фича-флагом в новом конструкторе. По умолчанию, это поведение отключено.

### Отчёт о тестировании
Подключил версию из текущего PR к своему роботу, написал в нём переподключение. Прикладываю логи того, что происходит при отключении и восстановлении интернета:

```
 % go run main.go
> Running the application daemon...
> Running the streaming API goroutine...
> Runned!
> Successfully connected! Running a read loop...
...
> Error while streaming read received: can't read message: read tcp ***.***.***.***:*****->178.248.239.55:443: i/o timeout. Reconnect...
> Trying to connect to Tinkoff...
> Failed to estabilish a streaming connection with Tinkoff. Retry #0 (delay: 10000 ms).
> Trying to connect to Tinkoff...
> Successfully connected! Running a read loop...